### PR TITLE
Add linting of Cucumber Steps syntax files.

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -18,7 +18,7 @@ class Rubocop(RubyLinter):
 
     """Provides an interface to rubocop."""
 
-    syntax = ('ruby', 'ruby on rails', 'rspec', 'betterruby', 'ruby experimental')
+    syntax = ('ruby', 'ruby on rails', 'rspec', 'betterruby', 'ruby experimental', 'cucumber steps')
     cmd = 'ruby -S rubocop --format emacs'
     version_args = '-S rubocop --version'
     version_re = r'(?P<version>\d+\.\d+\.\d+)'


### PR DESCRIPTION
Cucumber Steps files (syntax provided by the [Cucumber package](https://packagecontrol.io/packages/Cucumber)) contain a lot of Ruby code, and should therefore be lintable with Rubocop.
